### PR TITLE
Update underscore dependency that was causing a security error

### DIFF
--- a/lib/passport-authtkt/authtkt.js
+++ b/lib/passport-authtkt/authtkt.js
@@ -150,14 +150,14 @@ AuthTkt.prototype.validateCookie = function(ticket, options) {
  * Encode the given value to base65
  */
 AuthTkt.prototype.base64Encode = function(tkt) {
-    return new Buffer(tkt).toString('base64').trim();
+    return Buffer.from(tkt).toString('base64').trim();
 };
 
 /**
  * Decode the given value from base65
  */
 AuthTkt.prototype.base64Decode = function(val) {
-    return new Buffer(val, 'base64').toString('ascii');
+    return Buffer.from(val, 'base64').toString('ascii');
 };
 
 /**
@@ -198,7 +198,7 @@ AuthTkt.prototype.isEqual = function(val1, val2) {
  * Create a mod_auth_tkt digest
  */
 AuthTkt.prototype.createDigest = function(data1, data2) {
-    var digest0 = crypto.createHash('md5').update(Buffer.concat([new Buffer(data1), new Buffer(this.secret), new Buffer(data2)])).digest('hex');
+    var digest0 = crypto.createHash('md5').update(Buffer.concat([Buffer.from(data1), Buffer.from(this.secret), Buffer.from(data2)])).digest('hex');
     var digest = crypto.createHash('md5').update(digest0 + this.secret).digest('hex');
     return digest;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,153 @@
+{
+  "name": "passport-authtkt",
+  "version": "0.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jspack": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jspack/-/jspack-0.0.1.tgz",
+      "integrity": "sha1-qBgCOTkfOV3EsyiuqX+ivd/Og3Y="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "passport": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
+      "integrity": "sha1-yCZEedy2QUytu2Z1LRKzfgtlJaE=",
+      "requires": {
+        "pause": "0.0.1",
+        "pkginfo": "0.2.x"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+    },
+    "pkginfo": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
+    },
+    "sprintf": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.1.tgz",
+      "integrity": "sha1-6JJfyYlOGqaJnpCRx/KhITC3DeU="
+    },
+    "underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
+    "vows": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.3.tgz",
+      "integrity": "sha512-PVIxa/ovXhrw5gA3mz6M+ZF3PHlqX4tutR2p/y9NWPAaFVKcWBE8b2ktfr0opQM/qFmcOVWKjSCJVjnYOvjXhw==",
+      "dev": true,
+      "requires": {
+        "diff": "^4.0.1",
+        "eyes": "~0.1.6",
+        "glob": "^7.1.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "passport-authtkt",
-  "version": "0.0.2",
+  "name": "@aboutdotme/passport-authtkt",
+  "version": "1.0.0",
   "description": "mod_auth_tkt based authentication.",
   "keywords": [
     "passport",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "passport-authtkt",
   "version": "0.0.2",
   "description": "mod_auth_tkt based authentication.",
-  "keywords": ["passport", "auth_tkt", "auth", "authtkt", "authentication"],
+  "keywords": [
+    "passport",
+    "auth_tkt",
+    "auth",
+    "authtkt",
+    "authentication"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/optilude/passport-authtkt.git"
@@ -14,23 +20,27 @@
     "name": "Martin Aspeli",
     "email": "optilude@gmail.com"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT"
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib/passport-authtkt",
   "dependencies": {
-    "pkginfo": "0.2.x",
-    "passport": "~0.1.1",
-    "sprintf": "0.1.1",
     "jspack": "0.0.1",
-    "underscore": "1.4.4"
+    "passport": "~0.1.1",
+    "pkginfo": "0.2.x",
+    "sprintf": "0.1.1",
+    "underscore": "^1.13.1"
   },
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "^0.8.3"
   },
   "scripts": {
-    "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
+    "test": "vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 6"
+  }
 }

--- a/test/authtkt-test.js
+++ b/test/authtkt-test.js
@@ -1,7 +1,7 @@
 var vows = require('vows');
 var assert = require('assert');
 var util = require('util');
-var AuthTkt = require('passport-authtkt').AuthTkt;
+var AuthTkt = require('../lib/passport-authtkt').AuthTkt;
 
 vows.describe("AuthTkt").addBatch({
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,7 +1,7 @@
 var vows = require('vows');
 var assert = require('assert');
 var util = require('util');
-var authtkt = require('passport-authtkt');
+var authtkt = require('../lib/passport-authtkt');
 
 
 vows.describe('passport-authtkt').addBatch({

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -1,21 +1,21 @@
 var vows = require('vows');
 var assert = require('assert');
 var util = require('util');
-var AuthTktStrategy = require('passport-authtkt/strategy');
-var BadRequestError = require('passport-authtkt/errors/badrequesterror');
-var authtktutils = require('passport-authtkt/authtktutils');
+var AuthTktStrategy = require('../lib/passport-authtkt/strategy');
+var BadRequestError = require('../lib/passport-authtkt/errors/badrequesterror');
+var authtktutils = require('../lib/passport-authtkt/authtktutils');
 
 vows.describe('AuthTktStrategy').addBatch({
 
     'strategy': {
         topic: new AuthTktStrategy('abcdefghijklmnopqrstuvwxyz0123456789'),
-        
+
         'should be named authtkt': function (strategy) {
             assert.equal(strategy.name, 'authtkt');
         },
 
         'strategy handling a request without cookie middleware configured': {
-        
+
             topic: function(strategy) {
                 var self = this;
                 var req = {};
@@ -26,11 +26,11 @@ vows.describe('AuthTktStrategy').addBatch({
                 strategy.fail = function() {
                     self.callback(new Error('should-be-called'), req);
                 };
-            
+
                 req.res = {};
                 req.res.on = function(event, fn) {
                 };
-            
+
                 process.nextTick(function () {
                     try {
                         strategy.authenticate(req);
@@ -39,11 +39,11 @@ vows.describe('AuthTktStrategy').addBatch({
                     }
                 });
             },
-      
+
             'should fail' : function(err, req, user, info) {
                 assert.isNotNull(err);
             },
-            
+
             'should not set authInfo' : function(err, req, user, info) {
                 assert.isUndefined(req.authInfo);
             }
@@ -53,7 +53,7 @@ vows.describe('AuthTktStrategy').addBatch({
             topic: function() {
                 return new AuthTktStrategy('abcdefghijklmnopqrstuvwxyz0123456789');
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -66,21 +66,21 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-be-called'), req);
                     };
-                
+
                     req.cookies = {};
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                         strategy.authenticate(req);
                     });
                 },
-          
+
                 'should fail' : function(err, req, user, info) {
                     assert.isNotNull(err);
                 },
-                
+
                 'should not set authInfo' : function(err, req, user, info) {
                     assert.isUndefined(req.authInfo);
                 }
@@ -91,7 +91,7 @@ vows.describe('AuthTktStrategy').addBatch({
             topic: function() {
                 return new AuthTktStrategy('abcdefghijklmnopqrstuvwxyz0123456789');
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -104,23 +104,23 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-be-called'), req);
                     };
-                
+
                     req.cookies = {
                         authtkt: 'foo'
                     };
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                         strategy.authenticate(req);
                     });
                 },
-          
+
                 'should fail' : function(err, req, user, info) {
                     assert.isNotNull(err);
                 },
-                
+
                 'should not set authInfo' : function(err, req, user, info) {
                     assert.isUndefined(req.authInfo);
                 }
@@ -131,7 +131,7 @@ vows.describe('AuthTktStrategy').addBatch({
             topic: function() {
                 return new AuthTktStrategy('abcdefghijklmnopqrstuvwxyz0123456789');
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -144,23 +144,23 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-not-be-called'), req);
                     };
-                
+
                     req.cookies = {
                         authtkt: 'YzdjNzMwMGFjNWNmNTI5NjU2NDQ0MTIzYWNhMzQ1Mjk0ODg1YWZhMGpibG9nZ3Mh'
                     };
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should not fail' : function(err, req, user, info) {
                     assert.isNull(err);
                 },
-                
+
                 'should set authInfo' : function(err, req, user, info) {
                     assert.deepEqual(info, {
                         digest: 'c7c7300ac5cf529656444123aca34529',
@@ -193,7 +193,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     encodeUserData: false
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -206,23 +206,23 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-not-be-called'), req);
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFKb2UgQmxvZ2dz'
                     };
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should not fail' : function(err, req, user, info) {
                     assert.isNull(err);
                 },
-                
+
                 'should set authInfo' : function(err, req, user, info) {
                     assert.deepEqual(info, {
                         digest: 'eea3630e98177bdbf0e7f803e1632b7e',
@@ -253,7 +253,7 @@ vows.describe('AuthTktStrategy').addBatch({
             topic: function() {
                 return new AuthTktStrategy('abcdefghijklmnopqrstuvwxyz0123456789');
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -266,23 +266,23 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-not-be-called'), req);
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFKb2UgQmxvZ2dz'
                     };
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req, {encodeUserData: false});
                     });
                 },
-          
+
                 'should not fail' : function(err, req, user, info) {
                     assert.isNull(err);
                 },
-                
+
                 'should set authInfo' : function(err, req, user, info) {
                     assert.deepEqual(info, {
                         digest: 'eea3630e98177bdbf0e7f803e1632b7e',
@@ -315,7 +315,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     encodeUserData: true
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -328,23 +328,23 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         self.callback(new Error('should-not-be-called'), req);
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFKb2UgQmxvZ2dz'
                     };
                     req.res = {};
                     req.res.on = function(event, fn) {
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req, {encodeUserData: false});
                     });
                 },
-          
+
                 'should not fail' : function(err, req, user, info) {
                     assert.isNull(err);
                 },
-                
+
                 'should set authInfo' : function(err, req, user, info) {
                     assert.deepEqual(info, {
                         digest: 'eea3630e98177bdbf0e7f803e1632b7e',
@@ -382,7 +382,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -395,7 +395,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -410,12 +410,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -447,7 +447,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -460,7 +460,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -475,12 +475,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -513,7 +513,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -526,7 +526,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -541,12 +541,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -579,7 +579,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -592,7 +592,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -607,12 +607,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -645,7 +645,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -658,7 +658,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -673,12 +673,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -700,7 +700,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp + 10
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -713,7 +713,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     strategy.fail = function() {
                         assert.fail(); // should not happen
                     };
-                
+
                     req.cookies = {
                         authtkt: 'ZWVhMzYzMGU5ODE3N2JkYmYwZTdmODAzZTE2MzJiN2U0ODg1YWZhMGpibG9nZ3MhZm9vLGJhciFTbTlsSUVKc2IyZG5jdz09'
                     };
@@ -728,12 +728,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         assert.fail(); // should not happen
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },
@@ -756,7 +756,7 @@ vows.describe('AuthTktStrategy').addBatch({
                     timestamp: timestamp
                 });
             },
-    
+
             'after augmenting with actions': {
                 topic: function(strategy) {
                     var self = this;
@@ -767,9 +767,9 @@ vows.describe('AuthTktStrategy').addBatch({
                     };
 
                     strategy.fail = function() {
-                        
+
                     };
-                
+
                     req.cookies = {};
                     req.res = {};
                     req.res.cookies = {};
@@ -782,12 +782,12 @@ vows.describe('AuthTktStrategy').addBatch({
                     req.res.cookie = function(name, val) {
                         req.res.cookies[name] = val;
                     };
-                
+
                     process.nextTick(function () {
                          strategy.authenticate(req);
                     });
                 },
-          
+
                 'should register a header event handler': function(req, event, fn) {
                     assert.equal(event, 'header');
                 },


### PR DESCRIPTION
* Also update outdated use of `Buffer()` (which only applies for node 6+)
* Minor tweaks to make the tests pass
* Sorry, my editor also made some whitespace changes